### PR TITLE
[sc-782] Add missing cypher dsl functionality

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -1,3 +1,31 @@
+// OpenCypher9 Spec - Types of constraints
+// ---------------------------------------
+// C - Completed
+// IP - In progress
+// P - Planned
+// NS - Not supported
+// ---------------------------------------
+// [C] 1. Boolean operations (n.name = 'Peter' XOR (n.age < 30 AND n.name = 'Tobias') OR NOT (n.name = 'Tobias' OR n.name = 'Peter'))
+// [C] 2. Filter on node label (n:Swedish)
+// [C] 3. Filter on node property (n.age > 30)
+// [?] 4. Filter on relationship property (k.since < 2000)
+// [?] 5. Filter on dynamically-computed node property (n[toLower(propname)]< 30)
+// [C] 6. Property existence checking (exists(n.belt))
+// [C] 7. Match the beginning of a string (n.name STARTS WITH 'Pet')
+// [C] 8. Match the ending of a string (n.name ENDS WITH 'ter')
+// [C] 9. Match anywhere within a string (n.name CONTAINS 'ete')
+// [C] 10. String matching negation (NOT n.name ENDS WITH 's')
+// [C] 11. Filter on patterns (others.name IN ['Andres', 'Peter'] AND (tobias)<-[]-(others))
+// [C] 12. Filter on patterns using NOT (NOT (persons)-[]->(peter))
+// [C] 13. Filter on patterns with properties ((n)-[:KNOWS]-({name: 'Tobias'}))
+// [?] 14. Filter on relationship type (n.name='Andres' AND type(r) STARTS WITH 'K')
+// [C] 15. IN operator (a.name IN ['Peter', 'Tobias'])
+// [?] 16. Default to false if property is missing (n.belt = 'white')
+// [?] 17. Default to true if property is missing (n.belt = 'white' OR n.belt IS NULL RETURN n.name, n.age, n.belt)
+// [?] 18. Filter on null (person.name = 'Peter' AND person.belt IS NULL RETURN person.name, person.age, person.belt)
+// [C] 19. Simple range (a.name >= 'Peter')
+// [C] 20. Composite range (a.name > 'Andres' AND a.name < 'Tobias')
+
 package go_cypherdsl
 
 import (
@@ -12,7 +40,7 @@ type ConditionBuilder struct {
 	errors  []error
 }
 
-//should be used to start a condition chain
+// C is used to start a condition chain provided with a ConditionConfig
 func C(condition *ConditionConfig) ConditionOperator {
 	wq, err := NewCondition(condition)
 
@@ -249,7 +277,8 @@ const (
 	GreaterThanOperator          BooleanOperator = ">"
 	LessThanOrEqualToOperator    BooleanOperator = "<="
 	GreaterThanOrEqualToOperator BooleanOperator = ">="
-	EqualToOperator              BooleanOperator = "="
+	EqualToOperator              BooleanOperator = "="  // TODO: Rename to `EqualityOperator` to match OC9 spec
+	NotEqualToOperator           BooleanOperator = "<>" // TODO: Rename to `InequalityOperator` to match OC9 spec
 	InOperator                   BooleanOperator = "IN"
 	IsOperator                   BooleanOperator = "IS"
 	RegexEqualToOperator         BooleanOperator = "=~"
@@ -258,75 +287,118 @@ const (
 	ContainsOperator             BooleanOperator = "CONTAINS"
 )
 
-//configuration object for where condition
+// ConditionConfig is the configuration object for where conditions
 type ConditionConfig struct {
-	//operators that can be used
+	// Either ConditionOperator or ConditionFunction can be set, depending on whether an operator (e.g. '=') is
+	// required, or a function (e.g. exists()). Both cannot be specified.
 	ConditionOperator BooleanOperator
 
 	//condition functions that can be used
 	ConditionFunction string
 
+	// When constructing a conditional, Name must be specified (unless filtering on a Path). Additionally, either
+	// Field or Label must be specified (but not both). If Field is specified, FieldManipulationFunction is an
+	// optional function that can be specified to manipulate the specified Field during the query. If Label
+	// is specified, all other fields (other than Name and NegateCondition) will be ignored.
 	Name  string
-	Field string
+	Field string // TODO: Rename to `Property` to match OC9 spec
 	Label string
 
 	//exclude parentheses
 	FieldManipulationFunction string
 
-	//if its a single check
+	// When filtering on a Path, the only other field that can be specified is NegateCondition.
+	Path *PathBuilder
+
+	// When using any operator to compare to a specific value (other than InOperator), this field must be specified.
+	// If Check and (CheckName, CheckField) are both specified - (CheckName, CheckField) will take precedence.
 	Check interface{}
 
-	//if its a slice check
+	// When comparing one node to another, CheckField and CheckName must be specified.
+	CheckName  string
+	CheckField string
+
+	// When using the InOperator, this field must be specified. This will not apply to any other operators.
 	CheckSlice []interface{}
+
+	// When NegateCondition is set to true, NOT is appended to the start of this condition to apply a logical
+	// negation to the statement.
+	NegateCondition bool
 }
 
 func (condition *ConditionConfig) ToString() (string, error) {
+	var sb strings.Builder
+
+	if condition.NegateCondition {
+		sb.WriteString("NOT ")
+	}
+
+	if condition.Path != nil {
+		cypher, err := condition.Path.ToCypher()
+		if err != nil {
+			return "", fmt.Errorf("error converting path to cypher: %s", err)
+		}
+		sb.WriteString(cypher)
+		return sb.String(), nil
+	}
+
 	//check initial error conditions
 	if condition.Name == "" {
-		return "", errors.New("var name can not be empty")
+		return "", errors.New("to construct a query, Name must be specified")
 	}
 
-	if (condition.Field == "" && condition.Label == "") && condition.FieldManipulationFunction == "" {
-		return "", errors.New("field, function or label can not be empty")
+	if condition.Label == "" && (condition.Field == "" && condition.FieldManipulationFunction == "") {
+		return "", errors.New("either Label or (Field, FieldManipulationFunction) must be specified")
 	}
 
-	if condition.Field != "" && condition.Label != "" && condition.FieldManipulationFunction != "" {
-		return "", errors.New("field and label can not both be defined")
+	if condition.Field != "" && condition.Label != "" {
+		return "", errors.New("only one of Field and Label can be specified")
 	}
 
-	query := ""
+	if condition.FieldManipulationFunction != "" && condition.Field == "" {
+		return "", errors.New("if FieldManipulationFunction is specified, Field must also be specified")
+	}
 
-	//build the fields
+	if condition.Label != "" {
+		sb.WriteString(fmt.Sprintf("%s:%s", condition.Name, condition.Label))
+		return sb.String(), nil
+	}
+
+	var node string
 	if condition.Field != "" {
-		query += fmt.Sprintf("%s.%s", condition.Name, condition.Field)
-	} else if condition.Label != "" {
-		//we're done here
-		return fmt.Sprintf("%s:%s", condition.Name, condition.Label), nil
+		node = fmt.Sprintf("%s.%s", condition.Name, condition.Field)
 	} else {
-		query = condition.Name
+		node = condition.Name
 	}
 
 	if condition.FieldManipulationFunction != "" {
-		query = fmt.Sprintf("%s(%s)", condition.FieldManipulationFunction, query)
+		sb.WriteString(fmt.Sprintf("%s(%s)", condition.FieldManipulationFunction, node))
+	} else {
+		sb.WriteString(node)
 	}
 
 	if condition.ConditionOperator == "" && condition.ConditionFunction == "" {
-		return "", errors.New("either condition operator or condition function has to be defined")
+		return "", errors.New("one of ConditionOperator or ConditionFunction must be specified")
 	}
 
 	if condition.ConditionOperator != "" && condition.ConditionFunction != "" {
-		return "", errors.New("operator and function can not both be defined")
+		return "", errors.New("only one of ConditionOperator or ConditionFunction can be specified")
 	}
 
-	//build the operators
-	if condition.ConditionOperator != "" {
-		query += fmt.Sprintf(" %s", condition.ConditionOperator)
-	} else if condition.ConditionFunction != "" {
-		//if its a condition function, we're done
-		return fmt.Sprintf("%s(%s)", condition.ConditionFunction, query), nil
+	// Handle ConditionFunction if specified
+	if condition.ConditionFunction != "" {
+		if condition.NegateCondition {
+			return fmt.Sprintf(
+				"NOT %s(%s)", condition.ConditionFunction, strings.Trim(sb.String(), "NOT "),
+			), nil
+		}
+		return fmt.Sprintf("%s(%s)", condition.ConditionFunction, sb.String()), nil
 	}
 
-	//check if its valid for in
+	// Add ConditionOperator to query
+	sb.WriteString(fmt.Sprintf(" %s", condition.ConditionOperator))
+
+	// Handle edge cases for specific ConditionOperator types
 	if condition.ConditionOperator == InOperator {
 		if condition.CheckSlice == nil {
 			return "", errors.New("slice can not be nil")
@@ -351,16 +423,20 @@ func (condition *ConditionConfig) ToString() (string, error) {
 			q += fmt.Sprintf("%s,", str)
 		}
 
-		query += " " + strings.TrimSuffix(q, ",") + "]"
+		sb.WriteString(fmt.Sprintf(" %s]", strings.TrimSuffix(q, ",")))
 	} else {
-		str, err := cypherizeInterface(condition.Check)
-		if err != nil {
-			return "", err
+		if condition.CheckName != "" && condition.CheckField != "" {
+			sb.WriteString(fmt.Sprintf(" %s.%s", condition.CheckName, condition.CheckField))
+		} else {
+			str, err := cypherizeInterface(condition.Check)
+			if err != nil {
+				return "", err
+			}
+			sb.WriteString(" " + str)
 		}
-		query += " " + str
 	}
 
-	return query, nil
+	return sb.String(), nil
 }
 
 func NewCondition(condition *ConditionConfig) (WhereQuery, error) {

--- a/condition.go
+++ b/condition.go
@@ -287,6 +287,10 @@ const (
 	ContainsOperator             BooleanOperator = "CONTAINS"
 )
 
+func (b BooleanOperator) String() string {
+	return string(b)
+}
+
 // ConditionConfig is the configuration object for where conditions
 type ConditionConfig struct {
 	// Either ConditionOperator or ConditionFunction can be set, depending on whether an operator (e.g. '=') is
@@ -360,7 +364,9 @@ func (condition *ConditionConfig) ToString() (string, error) {
 	}
 
 	if condition.Label != "" {
-		sb.WriteString(fmt.Sprintf("%s:%s", condition.Name, condition.Label))
+		sb.WriteString(condition.Name)
+		sb.WriteRune(':')
+		sb.WriteString(condition.Label)
 		return sb.String(), nil
 	}
 
@@ -372,7 +378,10 @@ func (condition *ConditionConfig) ToString() (string, error) {
 	}
 
 	if condition.FieldManipulationFunction != "" {
-		sb.WriteString(fmt.Sprintf("%s(%s)", condition.FieldManipulationFunction, node))
+		sb.WriteString(condition.FieldManipulationFunction)
+		sb.WriteRune('(')
+		sb.WriteString(node)
+		sb.WriteRune(')')
 	} else {
 		sb.WriteString(node)
 	}
@@ -396,8 +405,8 @@ func (condition *ConditionConfig) ToString() (string, error) {
 	}
 
 	// Add ConditionOperator to query
-	sb.WriteString(fmt.Sprintf(" %s", condition.ConditionOperator))
-
+	sb.WriteRune(' ')
+	sb.WriteString(condition.ConditionOperator.String())
 	// Handle edge cases for specific ConditionOperator types
 	if condition.ConditionOperator == InOperator {
 		if condition.CheckSlice == nil {
@@ -423,16 +432,22 @@ func (condition *ConditionConfig) ToString() (string, error) {
 			q += fmt.Sprintf("%s,", str)
 		}
 
-		sb.WriteString(fmt.Sprintf(" %s]", strings.TrimSuffix(q, ",")))
+		sb.WriteRune(' ')
+		sb.WriteString(strings.TrimSuffix(q, ","))
+		sb.WriteRune(']')
 	} else {
 		if condition.CheckName != "" && condition.CheckField != "" {
-			sb.WriteString(fmt.Sprintf(" %s.%s", condition.CheckName, condition.CheckField))
+			sb.WriteRune(' ')
+			sb.WriteString(condition.CheckName)
+			sb.WriteRune('.')
+			sb.WriteString(condition.CheckField)
 		} else {
 			str, err := cypherizeInterface(condition.Check)
 			if err != nil {
 				return "", err
 			}
-			sb.WriteString(" " + str)
+			sb.WriteRune(' ')
+			sb.WriteString(str)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,16 @@
-module github.com/mindstand/go-cypherdsl
+module github.com/SGNL-ai/go-cypherdsl
 
-go 1.12
+go 1.18
 
 require (
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.5.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,6 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwg
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/params.go
+++ b/params.go
@@ -3,6 +3,7 @@ package go_cypherdsl
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -52,11 +53,18 @@ func (p *Params) ToCypherMap() string {
 		return "{}"
 	}
 
-	q := ""
+	// Create and sort a slice of keys to ensure cypher queries are created with consistent ordering
+	keys := make([]string, 0, len(p.params))
+	for k, _ := range p.params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 
-	for _, v := range p.params {
-		q += fmt.Sprintf("%s,", v)
+	var sb strings.Builder
+
+	for _, k := range keys {
+		sb.WriteString(fmt.Sprintf("%s,", p.params[k]))
 	}
 
-	return "{" + strings.TrimSuffix(q, ",") + "}"
+	return fmt.Sprintf("{%s}", strings.TrimSuffix(sb.String(), ","))
 }

--- a/params.go
+++ b/params.go
@@ -66,5 +66,5 @@ func (p *Params) ToCypherMap() string {
 		sb.WriteString(fmt.Sprintf("%s,", p.params[k]))
 	}
 
-	return fmt.Sprintf("{%s}", strings.TrimSuffix(sb.String(), ","))
+	return "{" + strings.TrimSuffix(sb.String(), ",") + "}"
 }

--- a/params_test.go
+++ b/params_test.go
@@ -11,6 +11,7 @@ func TestParams(t *testing.T) {
 		"val2": int(1),
 		"val3": true,
 		"val4": float64(43.444),
+		"val5": FuncString("datetime.realtime()"),
 	})
 	require.Nil(t, err)
 	require.NotNil(t, params)
@@ -19,6 +20,7 @@ func TestParams(t *testing.T) {
 	require.Contains(t, params.ToCypherMap(), "val1:'string'")
 	require.Contains(t, params.ToCypherMap(), "val2:1")
 	require.Contains(t, params.ToCypherMap(), "val3:true")
+	require.Contains(t, params.ToCypherMap(), "val5:datetime.realtime()")
 
 	//error test
 	err = params.Set("val", struct {

--- a/query.go
+++ b/query.go
@@ -53,6 +53,12 @@ func (p *ParamString) ToString() string {
 	return string(*p)
 }
 
+type FuncString string
+
+func (p *FuncString) ToString() string {
+	return string(*p)
+}
+
 type FunctionConfig struct {
 	Name   string
 	Params []interface{}

--- a/set.go
+++ b/set.go
@@ -3,6 +3,7 @@ package go_cypherdsl
 import (
 	"errors"
 	"fmt"
+	"reflect"
 )
 
 type SetOperation string
@@ -120,7 +121,9 @@ func (s *SetConfig) ToString() (string, error) {
 	//validate target node combo
 	if s.Member == "" && (s.Target != nil || s.TargetFunction != nil) {
 		//cant do this kind of operation directly on a node
-		return "", errors.New("can only set node equal to a map")
+		if reflect.TypeOf(s.Target) != reflect.TypeOf(ParamString("")) {
+			return "", errors.New("can only set node equal to a map")
+		}
 	}
 
 	if s.Member != "" {

--- a/set_test.go
+++ b/set_test.go
@@ -73,6 +73,16 @@ func TestSetConfig_ToString(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("f.t = 1", cypher)
 
+	//check set target to param string
+	t6 := &SetConfig{
+		Operation: SetEqualTo,
+		Target:    ParamString("$props"),
+		Name:      "f",
+	}
+	cypher, err = t6.ToString()
+	req.Nil(err)
+	req.EqualValues("f = $props", cypher)
+
 	//error - name not defined
 	e1 := &SetConfig{}
 	_, err = e1.ToString()

--- a/util.go
+++ b/util.go
@@ -21,6 +21,11 @@ func cypherizeInterface(i interface{}) (string, error) {
 		return string(s), nil
 	}
 
+	if t == reflect.TypeOf(FuncString("")) {
+		s := i.(FuncString)
+		return string(s), nil
+	}
+
 	//check string
 	if k == reflect.String {
 		return fmt.Sprintf("'%s'", i.(string)), nil


### PR DESCRIPTION
This PR adds the following missing functionality:
- Update go version and package name to match new repo
- Add FuncString (to pass functions as parameters)
- Ability to negate conditionals
- Add not equal to operator
- Add support for path conditionals
- Add support to compare 2 nodes to each other
- Sort parameters while constructing cypher strings to ensure consistent responses
- Add support to SET a single ParameterString