### PR TITLE
Add support for param string as target in MergeSetConfig and as CheckSlice in ConditionConfig

### DIFF
--- a/condition_test.go
+++ b/condition_test.go
@@ -29,10 +29,10 @@ func TestGetStrVersion(t *testing.T) {
 }
 
 func TestNewCondition(t *testing.T) {
-	//good condition checks
+	// good condition checks
 	req := require.New(t)
 
-	//exists(type.value)
+	// exists(type.value)
 	cypher, err := NewCondition(&ConditionConfig{
 		ConditionFunction: "exists",
 		Name:              "type",
@@ -41,7 +41,7 @@ func TestNewCondition(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("exists(type.value)", cypher.ToString())
 
-	//exists(toLower(type.value)
+	// exists(toLower(type.value)
 	cypher, err = NewCondition(&ConditionConfig{
 		ConditionFunction:         "exists",
 		FieldManipulationFunction: "toLower",
@@ -51,7 +51,7 @@ func TestNewCondition(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("exists(toLower(type.value))", cypher.ToString())
 
-	//type.value >= 1
+	// type.value >= 1
 	cypher, err = NewCondition(&ConditionConfig{
 		Name:              "type",
 		Field:             "value",
@@ -61,7 +61,7 @@ func TestNewCondition(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("type.value >= 1", cypher.ToString())
 
-	//type.value = 'test'
+	// type.value = 'test'
 	cypher, err = NewCondition(&ConditionConfig{
 		Name:              "type",
 		Field:             "value",
@@ -71,7 +71,7 @@ func TestNewCondition(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("type.value = 'test'", cypher.ToString())
 
-	//type.value != 'test'
+	// type.value != 'test'
 	cypher, err = NewCondition(&ConditionConfig{
 		Name:              "type",
 		Field:             "value",
@@ -81,7 +81,7 @@ func TestNewCondition(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("type.value <> 'test'", cypher.ToString())
 
-	//type.value in ['test','test2']
+	// type.value in ['test','test2']
 	cypher, err = NewCondition(&ConditionConfig{
 		Name:              "type",
 		Field:             "value",
@@ -91,7 +91,17 @@ func TestNewCondition(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("type.value IN ['test','test2']", cypher.ToString())
 
-	//type.value IS NULL
+	// type.value in param string
+	cypher, err = NewCondition(&ConditionConfig{
+		Name:              "type",
+		Field:             "value",
+		ConditionOperator: InOperator,
+		Check:             ParamString("$props"),
+	})
+	req.Nil(err)
+	req.EqualValues("type.value IN $props", cypher.ToString())
+
+	// type.value IS NULL
 	cypher, err = NewCondition(&ConditionConfig{
 		Name:              "type",
 		Field:             "value",
@@ -101,16 +111,16 @@ func TestNewCondition(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("type.value IS NULL", cypher.ToString())
 
-	//error checks
-	//nil check
+	// error checks
+	// nil check
 	_, err = NewCondition(nil)
 	req.NotNil(err)
 
-	//checks label and field not defined
+	// checks label and field not defined
 	_, err = NewCondition(&ConditionConfig{Name: "sfgs"})
 	req.NotNil(err)
 
-	//checks label and field both defined
+	// checks label and field both defined
 	_, err = NewCondition(&ConditionConfig{
 		Name:  "adfa",
 		Label: "dasdf",
@@ -118,14 +128,14 @@ func TestNewCondition(t *testing.T) {
 	})
 	req.NotNil(err)
 
-	//check operator and function not defined
+	// check operator and function not defined
 	_, err = NewCondition(&ConditionConfig{
 		Name:  "adfa",
 		Field: "dafsd",
 	})
 	req.NotNil(err)
 
-	//check operator and function both defined
+	// check operator and function both defined
 	_, err = NewCondition(&ConditionConfig{
 		Name:              "adfa",
 		Field:             "dafsd",
@@ -134,7 +144,7 @@ func TestNewCondition(t *testing.T) {
 	})
 	req.NotNil(err)
 
-	//check IN slice is nil
+	// check IN slice is nil
 	_, err = NewCondition(&ConditionConfig{
 		Name:              "adfa",
 		Field:             "dafsd",
@@ -143,7 +153,7 @@ func TestNewCondition(t *testing.T) {
 	})
 	req.NotNil(err)
 
-	//check IN non slice check is not nil
+	// check IN param string check i nil
 	_, err = NewCondition(&ConditionConfig{
 		Name:              "adfa",
 		Field:             "dafsd",
@@ -152,7 +162,7 @@ func TestNewCondition(t *testing.T) {
 	})
 	req.NotNil(err)
 
-	//check IN slice is empty
+	// check IN slice is empty
 	_, err = NewCondition(&ConditionConfig{
 		Name:              "adfa",
 		Field:             "dafsd",
@@ -161,7 +171,7 @@ func TestNewCondition(t *testing.T) {
 	})
 	req.NotNil(err)
 
-	//check invalid generic
+	// check invalid generic
 	_, err = NewCondition(&ConditionConfig{
 		Name:              "adfa",
 		Field:             "dafsd",
@@ -248,7 +258,7 @@ func TestNewCondition(t *testing.T) {
 func TestConditionBuilder(t *testing.T) {
 	req := require.New(t)
 
-	//(name.type = 1)
+	// (name.type = 1)
 	cypher, err := C(&ConditionConfig{
 		Name:              "name",
 		Field:             "type",
@@ -258,7 +268,7 @@ func TestConditionBuilder(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("name.type = 1", cypher.ToString())
 
-	//name.type = 1 AND exists(name.type)
+	// name.type = 1 AND exists(name.type)
 	cypher, err = C(&ConditionConfig{
 		Name:              "name",
 		Field:             "type",
@@ -272,7 +282,7 @@ func TestConditionBuilder(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("name.type = 1 AND exists(name.type)", cypher.ToString())
 
-	//name.type = 1 AND (name.otherType >= 1 OR name.str STARTS WITH 'test')
+	// name.type = 1 AND (name.otherType >= 1 OR name.str STARTS WITH 'test')
 	cypher, err = C(&ConditionConfig{
 		Name:              "name",
 		Field:             "type",
@@ -294,5 +304,5 @@ func TestConditionBuilder(t *testing.T) {
 	req.Nil(err)
 	req.EqualValues("name.type = 1 AND (name.otherType >= 1 OR name.str STARTS WITH 'test')", cypher.ToString())
 
-	//todo fail tests
+	// todo fail tests
 }

--- a/condition_test.go
+++ b/condition_test.go
@@ -153,7 +153,7 @@ func TestNewCondition(t *testing.T) {
 	})
 	req.NotNil(err)
 
-	// check IN param string check i nil
+	// check IN non slice check is not nil
 	_, err = NewCondition(&ConditionConfig{
 		Name:              "adfa",
 		Field:             "dafsd",

--- a/merge.go
+++ b/merge.go
@@ -2,26 +2,29 @@ package go_cypherdsl
 
 import (
 	"errors"
-	"fmt"
+	"reflect"
+	"strings"
 )
 
 type MergeConfig struct {
-	//the path its merging on
+	// the path its merging on
 	Path string
 
-	//what it does if its creating the node
+	// what it does if its creating the node
 	OnCreate *MergeSetConfig
 
-	//what it does if its matching the node
+	// what it does if its matching the node
 	OnMatch *MergeSetConfig
 }
 
 func (m *MergeConfig) ToString() (string, error) {
+	var sb strings.Builder
+
 	if m.Path == "" {
 		return "", errors.New("path can not be empty")
 	}
 
-	query := m.Path
+	sb.WriteString(m.Path)
 
 	if m.OnCreate != nil {
 		str, err := m.OnCreate.ToString()
@@ -29,7 +32,8 @@ func (m *MergeConfig) ToString() (string, error) {
 			return "", err
 		}
 
-		query += fmt.Sprintf(" ON CREATE SET %s", str)
+		sb.WriteString(" ON CREATE SET ")
+		sb.WriteString(str)
 	}
 
 	if m.OnMatch != nil {
@@ -38,33 +42,32 @@ func (m *MergeConfig) ToString() (string, error) {
 			return "", err
 		}
 
-		query += fmt.Sprintf(" ON MATCH SET %s", str)
+		sb.WriteString(" ON MATCH SET ")
+		sb.WriteString(str)
 	}
 
-	return query, nil
+	return sb.String(), nil
 }
 
 type MergeSetConfig struct {
-	//variable name
+	// variable name
 	Name string
 
-	//member variable of node
+	// member variable of node
 	Member string
 
-	//new value
+	// new value
 	Target interface{}
 
-	//new value if its a function, do not include
+	// new value if its a function, do not include
 	TargetFunction *FunctionConfig
 }
 
 func (m *MergeSetConfig) ToString() (string, error) {
+	var sb strings.Builder
+
 	if m.Name == "" {
 		return "", errors.New("name can not be empty")
-	}
-
-	if m.Member == "" {
-		return "", errors.New("member can not be empty")
 	}
 
 	if m.Target == nil && m.TargetFunction == nil {
@@ -75,21 +78,37 @@ func (m *MergeSetConfig) ToString() (string, error) {
 		return "", errors.New("target and target function can not both be defined")
 	}
 
-	query := fmt.Sprintf("%s.%s = ", m.Name, m.Member)
+	if m.Target != nil && (reflect.TypeOf(m.Target) == reflect.TypeOf(ParamString(""))) {
+		sb.WriteString(m.Name)
+		sb.WriteRune(' ')
+		sb.WriteString(EqualToOperator.String())
+		sb.WriteRune(' ')
+	} else {
+		if m.Member == "" {
+			return "", errors.New("member can not be empty")
+		}
+
+		sb.WriteString(m.Name)
+		sb.WriteRune('.')
+		sb.WriteString(m.Member)
+		sb.WriteRune(' ')
+		sb.WriteString(EqualToOperator.String())
+		sb.WriteRune(' ')
+	}
+
+	var str string
+	var err error
 
 	if m.Target != nil {
-		str, err := cypherizeInterface(m.Target)
-		if err != nil {
-			return "", err
-		}
-
-		return query + str, nil
+		str, err = cypherizeInterface(m.Target)
 	} else {
-		str, err := m.TargetFunction.ToString()
-		if err != nil {
-			return "", err
-		}
-
-		return query + str, nil
+		str, err = m.TargetFunction.ToString()
 	}
+
+	if err != nil {
+		return "", err
+	}
+
+	sb.WriteString(str)
+	return sb.String(), nil
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,8 +1,9 @@
 package go_cypherdsl
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeSetConfig_ToString(t *testing.T) {
@@ -75,6 +76,14 @@ func TestMergeConfig_ToString(t *testing.T) {
 
 	t5 := MergeConfig{}
 
+	t6 := MergeConfig{Path: "test", OnMatch: &MergeSetConfig{
+		Name:   "test",
+		Target: ParamString("$props"),
+	}, OnCreate: &MergeSetConfig{
+		Name:   "test",
+		Target: ParamString("$props"),
+	}}
+
 	req := require.New(t)
 	var err error
 	var cypher string
@@ -102,4 +111,9 @@ func TestMergeConfig_ToString(t *testing.T) {
 	//error - path not defined
 	_, err = t5.ToString()
 	req.NotNil(err)
+
+	//merge with on create and on match set to param string
+	cypher, err = t6.ToString()
+	req.Nil(err)
+	req.EqualValues("test ON CREATE SET test = $props ON MATCH SET test = $props", cypher)
 }


### PR DESCRIPTION
This PR updates `MergeSetConfig` to allow setting a target to a `ParamString` (and omitting a Member). Additionally, this adds support for creating a `ConditionConfig` with the `InOperator` set to a `ParamString` on the `Check` field, instead of requiring an `CheckSlice` field