### PR TITLE
Introduce PlusEqualOperator For Merging Nodes

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -73,7 +73,7 @@ func C(condition *ConditionConfig) ConditionOperator {
 	return cond
 }
 
-//add an error to the condition chain
+// add an error to the condition chain
 func (c *ConditionBuilder) addError(e error) {
 	if c.errors == nil {
 		c.errors = []error{e}
@@ -82,12 +82,12 @@ func (c *ConditionBuilder) addError(e error) {
 	}
 }
 
-//check if the builder has had any errors down the chain
+// check if the builder has had any errors down the chain
 func (c *ConditionBuilder) hasErrors() bool {
 	return c.errors != nil && len(c.errors) > 0
 }
 
-//add another node to the chain
+// add another node to the chain
 func (c *ConditionBuilder) addNext(node *operatorNode) error {
 	if node == nil {
 		return errors.New("node can not be nil")
@@ -280,6 +280,7 @@ const (
 	GreaterThanOrEqualToOperator BooleanOperator = ">="
 	EqualToOperator              BooleanOperator = "="  // TODO: Rename to `EqualityOperator` to match OC9 spec
 	NotEqualToOperator           BooleanOperator = "<>" // TODO: Rename to `InequalityOperator` to match OC9 spec
+	PlusEqualOperator            BooleanOperator = "+="
 	InOperator                   BooleanOperator = "IN"
 	IsOperator                   BooleanOperator = "IS"
 	RegexEqualToOperator         BooleanOperator = "=~"

--- a/merge.go
+++ b/merge.go
@@ -58,7 +58,7 @@ func (m *MergeConfig) ToString() (string, error) {
 			return "", err
 		}
 
-		sb.WriteString(" ON MATCH SET")
+		sb.WriteString(" ON MATCH")
 		sb.WriteString(str)
 	}
 
@@ -154,7 +154,7 @@ func (m *MergeSetConfigWithMembers) ToString() (string, error) {
 			return "", err
 		}
 
-		sb.WriteRune(' ')
+		sb.WriteString(" SET ")
 		sb.WriteString(m.Name)
 		sb.WriteRune('.')
 		sb.WriteString(k)

--- a/merge_test.go
+++ b/merge_test.go
@@ -73,7 +73,7 @@ func TestMergeSetConfigWithMembers_ToString(t *testing.T) {
 	//name members
 	cypher, err = t4.ToString()
 	req.Nil(err)
-	req.Contains(cypher, "test.key1 = 1", "test.key2 = 'value2'", "test.key3 = $key3")
+	req.Contains(cypher, " SET test.key1 = 1", " SET test.key2 = 'value2'", " SET test.key3 = $key3")
 }
 
 func TestMergeConfig_ToString(t *testing.T) {
@@ -156,6 +156,6 @@ func TestMergeConfig_ToString(t *testing.T) {
 	cypher, err = t7.ToString()
 	req.Nil(err)
 	req.Contains(cypher, "test ON CREATE SET test = $props")
-	req.Contains(cypher, " ON MATCH SET ", " test.key1 = 1", " test.key2 = 'value2'", " test.key3 = $key3")
-	req.Equal(98, len(cypher))
+	req.Contains(cypher, " ON MATCH SET ", " SET test.key1 = 1", " SET test.key2 = 'value2'", " SET test.key3 = $key3")
+	req.Equal(106, len(cypher))
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -46,34 +46,7 @@ func TestMergeSetConfig_ToString(t *testing.T) {
 	//error - target and target function defined
 	_, err = t6.ToString()
 	req.NotNil(err)
-}
 
-func TestMergeSetConfigWithMembers_ToString(t *testing.T) {
-	t1 := MultiMemberMergeSetConfig{Members: map[string]interface{}{"key": "value"}}
-	t2 := MultiMemberMergeSetConfig{Name: "test"}
-	t3 := MultiMemberMergeSetConfig{Name: "test", Members: map[string]interface{}{}}
-	t4 := MultiMemberMergeSetConfig{Name: "test", Members: map[string]interface{}{"key1": 1, "key2": "value2", "key3": ParamString("$value3")}}
-
-	req := require.New(t)
-	var err error
-	var cypher string
-
-	//error - name not defined
-	_, err = t1.ToString()
-	req.NotNil(err)
-
-	//error - members not defined
-	_, err = t2.ToString()
-	req.NotNil(err)
-
-	//error - members empty
-	_, err = t3.ToString()
-	req.NotNil(err)
-
-	//name members
-	cypher, err = t4.ToString()
-	req.Nil(err)
-	req.Contains(cypher, "test.key1 = 1", "test.key2 = 'value2'", "test.key3 = $value3")
 }
 
 func TestMergeConfig_ToString(t *testing.T) {
@@ -106,14 +79,7 @@ func TestMergeConfig_ToString(t *testing.T) {
 	t6 := MergeConfig{Path: "test", OnMatch: &MergeSetConfig{
 		Name:   "test",
 		Target: ParamString("$props"),
-	}, OnCreate: &MergeSetConfig{
-		Name:   "test",
-		Target: ParamString("$props"),
-	}}
-
-	t7 := MergeConfig{Path: "test", OnMatchSetMembers: &MultiMemberMergeSetConfig{
-		Name:    "test",
-		Members: map[string]interface{}{"key1": 1, "key2": "value2", "key3": ParamString("$value3")},
+		Type:   MERGE,
 	}, OnCreate: &MergeSetConfig{
 		Name:   "test",
 		Target: ParamString("$props"),
@@ -150,12 +116,5 @@ func TestMergeConfig_ToString(t *testing.T) {
 	//merge with on create and on match set to param string
 	cypher, err = t6.ToString()
 	req.Nil(err)
-	req.EqualValues("test ON CREATE SET test = $props ON MATCH SET test = $props", cypher)
-
-	//merge with on create and on match with members
-	cypher, err = t7.ToString()
-	req.Nil(err)
-	req.Contains(cypher, "test ON CREATE SET test = $props")
-	req.Contains(cypher, " ON MATCH SET ", "test.key1 = 1", "test.key2 = 'value2'", "test.key3 = $value3")
-	req.Equal(102, len(cypher))
+	req.EqualValues("test ON CREATE SET test = $props ON MATCH SET test += $props", cypher)
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -49,10 +49,10 @@ func TestMergeSetConfig_ToString(t *testing.T) {
 }
 
 func TestMergeSetConfigWithMembers_ToString(t *testing.T) {
-	t1 := MergeSetConfigWithMembers{Members: map[string]interface{}{"key": "value"}}
-	t2 := MergeSetConfigWithMembers{Name: "test"}
-	t3 := MergeSetConfigWithMembers{Name: "test", Members: map[string]interface{}{}}
-	t4 := MergeSetConfigWithMembers{Name: "test", Members: map[string]interface{}{"key1": 1, "key2": "value2", "key3": ParamString("$key3")}}
+	t1 := MultiMemberMergeSetConfig{Members: map[string]interface{}{"key": "value"}}
+	t2 := MultiMemberMergeSetConfig{Name: "test"}
+	t3 := MultiMemberMergeSetConfig{Name: "test", Members: map[string]interface{}{}}
+	t4 := MultiMemberMergeSetConfig{Name: "test", Members: map[string]interface{}{"key1": 1, "key2": "value2", "key3": ParamString("$value3")}}
 
 	req := require.New(t)
 	var err error
@@ -73,7 +73,7 @@ func TestMergeSetConfigWithMembers_ToString(t *testing.T) {
 	//name members
 	cypher, err = t4.ToString()
 	req.Nil(err)
-	req.Contains(cypher, " SET test.key1 = 1", " SET test.key2 = 'value2'", " SET test.key3 = $key3")
+	req.Contains(cypher, "test.key1 = 1", "test.key2 = 'value2'", "test.key3 = $value3")
 }
 
 func TestMergeConfig_ToString(t *testing.T) {
@@ -111,9 +111,9 @@ func TestMergeConfig_ToString(t *testing.T) {
 		Target: ParamString("$props"),
 	}}
 
-	t7 := MergeConfig{Path: "test", OnMatchWithMembers: &MergeSetConfigWithMembers{
+	t7 := MergeConfig{Path: "test", OnMatchSetMembers: &MultiMemberMergeSetConfig{
 		Name:    "test",
-		Members: map[string]interface{}{"key1": 1, "key2": "value2", "key3": ParamString("$key3")},
+		Members: map[string]interface{}{"key1": 1, "key2": "value2", "key3": ParamString("$value3")},
 	}, OnCreate: &MergeSetConfig{
 		Name:   "test",
 		Target: ParamString("$props"),
@@ -156,6 +156,6 @@ func TestMergeConfig_ToString(t *testing.T) {
 	cypher, err = t7.ToString()
 	req.Nil(err)
 	req.Contains(cypher, "test ON CREATE SET test = $props")
-	req.Contains(cypher, " ON MATCH SET ", " SET test.key1 = 1", " SET test.key2 = 'value2'", " SET test.key3 = $key3")
-	req.Equal(106, len(cypher))
+	req.Contains(cypher, " ON MATCH SET ", "test.key1 = 1", "test.key2 = 'value2'", "test.key3 = $value3")
+	req.Equal(102, len(cypher))
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -17,6 +17,13 @@ func TestMergeSetConfig_ToString(t *testing.T) {
 	t5 := MergeSetConfig{Name: "test", Member: "ttt"}
 	t6 := MergeSetConfig{Name: "test", Member: "ttt", TargetFunction: &FunctionConfig{Name: "test"}, Target: 1}
 
+	t7 := MergeSetConfig{Name: "test", Member: "ttt", TargetFunction: &FunctionConfig{Name: "test"}, Operator: EqualToOperator}
+	t8 := MergeSetConfig{Name: "test", Member: "ttt", TargetFunction: &FunctionConfig{Name: "test"}, Operator: PlusEqualOperator}
+
+	t9 := MergeSetConfig{Name: "test", Target: ParamString("$props"), Operator: EqualToOperator}
+	t10 := MergeSetConfig{Name: "test", Target: ParamString("$props"), Operator: PlusEqualOperator}
+	t11 := MergeSetConfig{Name: "test", Target: ParamString("$props"), Operator: ContainsOperator}
+
 	req := require.New(t)
 	var err error
 	var cypher string
@@ -47,6 +54,28 @@ func TestMergeSetConfig_ToString(t *testing.T) {
 	_, err = t6.ToString()
 	req.NotNil(err)
 
+	//name member target function operator
+	cypher, err = t7.ToString()
+	req.Nil(err)
+	req.EqualValues("test.ttt = test()", cypher)
+
+	//error - invalid operator defined
+	_, err = t8.ToString()
+	req.NotNil(err)
+
+	//name target operator
+	cypher, err = t9.ToString()
+	req.Nil(err)
+	req.EqualValues("test = $props", cypher)
+
+	//name target operator
+	cypher, err = t10.ToString()
+	req.Nil(err)
+	req.EqualValues("test += $props", cypher)
+
+	//error - invalid operator defined
+	_, err = t11.ToString()
+	req.NotNil(err)
 }
 
 func TestMergeConfig_ToString(t *testing.T) {
@@ -77,9 +106,9 @@ func TestMergeConfig_ToString(t *testing.T) {
 	t5 := MergeConfig{}
 
 	t6 := MergeConfig{Path: "test", OnMatch: &MergeSetConfig{
-		Name:   "test",
-		Target: ParamString("$props"),
-		Type:   MERGE,
+		Name:     "test",
+		Target:   ParamString("$props"),
+		Operator: PlusEqualOperator,
 	}, OnCreate: &MergeSetConfig{
 		Name:   "test",
 		Target: ParamString("$props"),


### PR DESCRIPTION
Introduce `PlusEqualOperator`, i.e., `+=` for merging nodes, which will overwrite the specified properties, and leave the unspecified properties untouched [reference](https://neo4j.com/docs/cypher-manual/4.4/clauses/set/#set-setting-properties-using-map).

Within the MergeConfig struct, introduce the `Type` field to differentiate `CREATE` versus `MERGE`.

In particular, this PR is the prerequisite of https://github.com/SGNL-ai/sgnl/pull/664, which requires updating a limit set of properties instead of all properties when updating ingestion nodes.